### PR TITLE
fix: guard icon update when SVG icon element is absent

### DIFF
--- a/dynamic-svg-editor.html
+++ b/dynamic-svg-editor.html
@@ -91,7 +91,9 @@
             toplineTextElement.setAttribute('fill', toplineColor);
             toplineTextElement.querySelector('tspan').textContent = toplineText;
 
-            iconShape.setAttribute('fill', iconColor);
+            if (iconShape) {
+                iconShape.setAttribute('fill', iconColor);
+            }
         }
 
         function generateBase64Code() {


### PR DESCRIPTION
## Summary
- avoid JS error in dynamic SVG editor when optional icon element is missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689640b733448330861d73a6db2c741d